### PR TITLE
 feat(ext): add transfer method to Request and Response

### DIFF
--- a/ext/fetch_base/23_request.js
+++ b/ext/fetch_base/23_request.js
@@ -14,9 +14,11 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypeSlice,
   ArrayPrototypeSplice,
+  ObjectDefineProperties,
   ObjectKeys,
   ObjectPrototypeIsPrototypeOf,
   RegExpPrototypeExec,
+  String,
   StringPrototypeStartsWith,
   Symbol,
   SymbolFor,
@@ -40,6 +42,7 @@ import {
   guardFromHeaders,
   headerListFromHeaders,
   headersFromHeaderList,
+  Headers,
 } from "ext:deno_fetch/20_headers.js";
 import { HttpClientPrototype } from "ext:deno_fetch/22_http_client.js";
 import {
@@ -305,6 +308,36 @@ class Request {
   }
 
   /**
+   * Constructs a `Request` object that includes the specified mutez transfer amount in its headers.
+   *
+   * @param {RequestInfo} input - The input to construct the request (URL or existing `Request`).
+   * @param {number} amount - The amount in mutez to transfer.
+   * @param {RequestInit} [init={}] - Optional request initialization object
+   *   (method, headers, body, signal, etc.). Existing headers are preserved.
+   * @returns {Request} A `Request` instance with the "X-JSTZ-TRANSFER" header set.
+   *
+   * @example
+   * // Create a POST request with transfer header and body
+   * const req = Request.withTransfer(
+   *   "jstz://tz1...",
+   *   5000,
+   *   { method: "POST", body: "send 5000 mutez" },
+   * );
+   *
+   * console.log(req.headers.get("X-JSTZ-TRANSFER")); // "5000"
+   */
+  static withTransfer(input, amount, init = { __proto__: null }) {
+    const headers = new Headers(init.headers);
+    headers.set("X-JSTZ-TRANSFER", String(amount));
+
+    return new Request(input, {
+      ...init,
+      headers,
+    });
+  }
+
+
+  /**
    * https://fetch.spec.whatwg.org/#dom-request
    * @param {RequestInfo} input
    * @param {RequestInit} init
@@ -538,6 +571,9 @@ class Request {
 }
 
 webidl.configureInterface(Request);
+ObjectDefineProperties(Request, {
+  withTransfer: { __proto__: null, enumerable: true },
+});
 const RequestPrototype = Request.prototype;
 mixinBody(RequestPrototype, _body, _mimeType);
 

--- a/ext/fetch_base/23_response.js
+++ b/ext/fetch_base/23_response.js
@@ -29,6 +29,7 @@ import {
   guardFromHeaders,
   headerListFromHeaders,
   headersFromHeaderList,
+  Headers,
 } from "ext:deno_fetch/20_headers.js";
 const {
   ArrayPrototypeMap,
@@ -39,6 +40,7 @@ const {
   RegExpPrototypeExec,
   SafeArrayIterator,
   SafeRegExp,
+  String,
   Symbol,
   SymbolFor,
   TypeError,
@@ -312,6 +314,35 @@ class Response {
   }
 
   /**
+   * Constructs a `Response` object that includes the specified mutez transfer amount in its headers.
+   *
+   * @param {BodyInit | null} [body=null] - Optional response body (e.g. string, Blob, or null for no body).
+   * @param {number} amount - The amount in mutez to transfer.
+   * @param {ResponseInit} [init={}] - Optional response initialization object (status, headers, etc.).
+   * @returns {Response} A `Response` instance with the "X-JSTZ-TRANSFER" header set.
+   *
+   * @example
+   * // Create a text response indicating a transfer message
+   * const res = Response.withTransfer(
+   *   "Transfer of 1000 mutez initiated successfully.",
+   *   1000,
+   *   { status: 200, headers: { "Content-Type": "text/plain" } }
+   * );
+   *
+   * console.log(await res.text()); // "Transfer of 1000 mutez initiated successfully."
+   * console.log(res.headers.get("X-JSTZ-TRANSFER")); // "1000"
+   */
+  static withTransfer(body = null, amount, init = { __proto__: null }) {
+    const headers = new Headers(init.headers);
+    headers.set("X-JSTZ-TRANSFER", String(amount));
+
+    return new Response(body, {
+      ...init,
+      headers,
+    });
+  }
+
+  /**
    * @param {BodyInit | null} body
    * @param {ResponseInit} init
    */
@@ -444,6 +475,7 @@ ObjectDefineProperties(Response, {
   json: { __proto__: null, enumerable: true },
   redirect: { __proto__: null, enumerable: true },
   error: { __proto__: null, enumerable: true },
+  withTransfer: { __proto__: null, enumerable: true },
 });
 const ResponsePrototype = Response.prototype;
 mixinBody(ResponsePrototype, _body, _mimeType);

--- a/ext/fetch_base/lib.deno_fetch.d.ts
+++ b/ext/fetch_base/lib.deno_fetch.d.ts
@@ -349,6 +349,7 @@ interface Request extends Body {
 declare var Request: {
   readonly prototype: Request;
   new (input: RequestInfo | URL, init?: RequestInit): Request;
+  withTransfer(input: RequestInfo | URL, amount: number, init?: RequestInit): Request;
 };
 
 /** @category Fetch */
@@ -392,6 +393,7 @@ declare var Response: {
   json(data: unknown, init?: ResponseInit): Response;
   error(): Response;
   redirect(url: string | URL, status?: number): Response;
+  withTransfer(body?: BodyInit | null, amount: number, init?: ResponseInit): Response;
 };
 
 /** Fetch a resource from the network. It returns a `Promise` that resolves to the


### PR DESCRIPTION
Added a static `withTransfer` method that constructs the `Response` and `Request` object. 
The method takes an `amount: number | string` and sets the header's value `X_JSTZ_TRANSFER=amount`. The reason behind making the api a static constructor method instead of a method that mutates the existing header is due to its [modification restrictions](https://developer.mozilla.org/en-US/docs/Web/API/Headers#modification_restrictions)

Related JSTZ pr: https://github.com/jstz-dev/jstz/pull/1348